### PR TITLE
Python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In this section, you'll see a demo of the final AI application you'll be buildin
 
 ### Install LangFlow using pip.
 
-### Ensure you have [Python 3.10](https://www.python.org/downloads/) or above installed.
+### Ensure you have [Python <3.13, >=3.10](https://www.python.org/downloads/) installed.
 
 - **Command to check Python version:**
 


### PR DESCRIPTION
Currently, langflow supports Python <3.13, >=3.10. It does not support latest version of Python i.e., 3.13. For reference: https://pypi.org/project/langflow/